### PR TITLE
Remove process_network_receive/transmit_bytes_total from displaying

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ The collected metrics include:
 - **Errors**: Total count and rate.
 - **Workers**: Active concurrent worker count.
 - **System**: User/system CPU usage and RSS memory usage.
-- **Network**: Bytes transmitted and received.
 - **Resources**: Open file descriptors, OS threads, and goroutines.
 
 ## Command-Line Tool

--- a/metrics/formatter.go
+++ b/metrics/formatter.go
@@ -101,6 +101,7 @@ func skipMetric(name string) bool {
 
 	skipExact := []string{
 		"go_sched_gomaxprocs_threads", "process_max_fds", "go_info",
+		"process_network_receive_bytes_total", "process_network_transmit_bytes_total",
 	}
 	return slices.Contains(skipExact, name)
 }


### PR DESCRIPTION
The Prometheus `client_golang` metrics `process_network_receive_bytes_total` and `process_network_transmit_bytes_total` read from `/proc/<pid>/net/netstat` on Linux. Despite their names, these metrics provide network namespace data rather than process-specific data.

I am removing these metrics from the dump display. Because the process is likely running in the root network namespace or sharing a namespace with other processes. These metrics include network traffic from all processes in that namespace.
